### PR TITLE
remove trailing slash from mui imports

### DIFF
--- a/src/module/components/Playlist/PlaylistControl.js
+++ b/src/module/components/Playlist/PlaylistControl.js
@@ -10,8 +10,8 @@ import {
   RepeatRounded,
   RepeatOnRounded,
   RepeatOneOnRounded,
-} from "@mui/icons-material/";
-import { Popover, Collapse, Box, ToggleButton } from "@mui/material/";
+} from "@mui/icons-material";
+import { Popover, Collapse, Box, ToggleButton } from "@mui/material";
 import styled from "@mui/material/styles/styled";
 
 import Playlist from "./Playlist.js";

--- a/src/module/components/Playlist/PlaylistItemTemplate.js
+++ b/src/module/components/Playlist/PlaylistItemTemplate.js
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import {
   PlayArrowRounded as PlayIcon,
   Menu as ReorderIcon,
-} from "@mui/icons-material/";
+} from "@mui/icons-material";
 import Box from "@mui/material/Box";
 
 import CoverArt from "../CoverArt";


### PR DESCRIPTION
removes the trailing slashes from mui imports, which broke #14 #15 